### PR TITLE
Clarify Libauth BCH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ There are various groups developing software stacks & apps for the broader ecosy
 ### Typescript
 - 💚 [Bitbox SDK](https://developer.bitcoin.com/bitbox/) [[docs]](https://developer.bitcoin.com/bitbox/docs/getting-started) [[src]](https://github.com/Bitcoin-com/bitbox-sdk/) - library for interacting with BCH via rest.bitcoin.com.
 - 💚 [Badger SDK](https://developer.bitcoin.com/badger/docs/getting-started) - browser extension wallet supporting BCH and SLP on webpages.
-- [libauth](https://libauth.org/) [[src]](https://github.com/bitauth/libauth) - a zero-dependency, typescript bitcoin library, including WASM crypto functions, BTC, but BCH friendly. (formerly bitcoin-ts)
+- [Libauth](https://libauth.org/) [[src]](https://github.com/bitauth/libauth) - an ultra-lightweight, zero-dependency library for Bitcoin Cash and Bitauth applications. (Formerly `bitcoin-ts`.)
 
 ### Python
 - [bitcash](https://pybitcash.github.io/bitcash/) [[src]](https://github.com/sporestack/bitcash) - python3 library.


### PR DESCRIPTION
Hey @2qx – thanks for putting together this repo! It's a fantastic resource.

Just wanted to clarify the description for Libauth – Libauth is really a BCH-first library, currently. The APIs are designed to easily support BTC, BSV, and future forks of BCH, but I really only spend time on the BCH support right now.

BTC is similar enough that most Libauth utilities work for BTC as-is, so I include "Bitcoin" in the tagline to help people find it. (e.g. Libauth is perfect for multi-coin wallets needing lightweight implementations of a few basic BTC utilities – being able to reuse most of the code between BCH and BTC can really reduce bundle size.)

For what it's worth, the [BTC VM implementation isn't even complete](https://github.com/bitauth/bitauth-ide/issues/28#issuecomment-577314552). 😅 (Though if someone out there is still interested in the BTC VM, I'm happy to take a PR!)