### PR TITLE
improve accuracy of consensus section

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,14 +379,11 @@ Just some good charities for the world at large.
 - [CashShuffle](https://cashshuffle.com/) [[spec]](https://github.com/cashshuffle/spec/blob/master/SPECIFICATION.md) - a privacy protocol for combining transactions with others, splitting to the lowest common amount.
 - [Price Oracle](https://gitlab.com/GeneralProtocols/priceoracle/specification) [[🐉implementation]](https://gitlab.com/GeneralProtocols/priceoracle/library) - Price oracle work in progress.
 
-## Improvement Proposals
-
-- [Bitcoin Cash Improveent Proposals (CHIPS)](https://gitlab.com/GeneralProtocols/research/chips)
-- [Bitcoin Unlimited Improvement Proposals (BUIPS)](https://www.bitcoinunlimited.info/voting/)
-
 ## Miner Consensus
 
-- [Bitcoin Mining Parlament](https://bmp.virtualpol.com/) [[README]](https://bmp.virtualpol.com/README) [[src]](https://github.com/JavierGonzalez/BMP) - A decentralized place to talk, vote and more with delegated hashpower. 
+- [List of Known Cash Improvement Proposals (CHIPs)](https://bch.info/chips) - documents that record proposals to upgrade the Bitcoin Cash protocol, and their ongoing progress, both technical and consensus-building.
+- [Process for Cash Improvement Proposals (CHIPs)](https://gitlab.com/im_uname/cash-improvement-proposals/-/blob/master/CHIPs.md) - a shared ecosystem process to achieve one positive change on the BCH network.
+- [Bitcoin Mining Parliament](https://bmp.virtualpol.com/) [[README]](https://bmp.virtualpol.com/README) [[src]](https://github.com/JavierGonzalez/BMP) - a decentralized place to talk, vote and more with delegated hashpower.
 
 ## Bitcoin Script
 
@@ -405,6 +402,7 @@ Just some good charities for the world at large.
 
 - [BCHN](https://bitcoincashnode.org/) [[src]](https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node) [[docs]](https://docs.bitcoincashnode.org/) - a descendant of the Bitcoin Core and Bitcoin ABC software projects with independent development team. C/C++.
 - [BitcoinUnlimited](https://www.bitcoinunlimited.info/) [[src]](https://github.com/BitcoinUnlimited/BitcoinUnlimited) - a full node implentation focused on supporting user needs, C/C++.
+    - [Bitcoin Unlimited Improvement Proposals (BUIPS)](https://www.bitcoinunlimited.info/voting/)
 - [Flowee the Hub](https://flowee.org/) [[src]](https://gitlab.com/FloweeTheHub) - a node supporting a suite of software focused on payment integration. C++
 - [Bitcoin Verde](https://bitcoinverde.org/) [[src]](https://github.com/softwareverde/bitcoin-verde) [[docs]](https://explorer.bitcoinverde.org/documentation/) - java implementation with the goal of being interoperable with mining nodes.
 - [Knuth](https://kth.cash/) [[src]](https://github.com/k-nuth/kth) - a high performance implementation of the Bitcoin protocol focused on applications needing extra capacity and resilience.


### PR DESCRIPTION
Main improvements:

- merge improvement proposals and consensus since CHIP is 95% intended for consensus
- fix some minor typos on related changed lines (spelling, trailing whitespace, capitalization)
- move BUIP to Bitcoin Unlimited since they are about BU as an organization, not BCH
- remove link to general protocols for CHIPs since those are just the CHIPs that we worked on. Replaced with a list of known CHIPs and a separate link to the process itself.