### PR TITLE
Add BitcoinVN to Centralized Exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ Bitcoin Cash is supported on hundreds of exchanges, these are a few.
 
 - [Coinflex](https://coinflex.com) - Coin Futures and Lending Exchange
 - [CoinEx](https://www.coinex.com) - A professional global cryptocurrency exchange (BCH friendly)
-  
+- [BitcoinVN](https://bitcoinvn.io) - Non-custodial instant exchange supporting BCH since day one, with 0-conf deposits for small amounts.
+
 ## Faucets
 - [BCH Testnet Faucet](https://faucet.fullstack.cash/) [[src]](https://github.com/christroutner/testnet-faucet2/) - Fullstack.cash faucet for tBCH.
 - [Testnet Faucet](https://tbch.googol.cash/) [[src]](https://gitlab.com/uak/light-crypto-faucet)


### PR DESCRIPTION
## Summary

Adds [BitcoinVN](https://bitcoinvn.io) to the "More established" Centralized Exchanges section.

BitcoinVN is a non-custodial instant exchange that has supported Bitcoin Cash since its launch on day one (August 1, 2017). It offers 0-conf (zero-confirmation) deposits for small BCH amounts, enabling instant transactions — making it a natural fit for this list.

Operating since 2014, BitcoinVN uses a non-custodial instant swap model and also supports BTC (Lightning), ETH, USDT, XMR, ZEC, LTC, and DASH.