### PR TITLE
Fix malformed Midori Wallet markdown links and URL typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,17 @@ Below are non-custodial open-source wallets that use features specific to Bitcoi
 - [Stack Wallet](https://stackwallet.com/) [[code]](https://github.com/cypherstack/stack_wallet) - Multicoin wallet with UTXO (coin) control.
 - [Cake Wallet](https://cakewallet.com/) [[code]](https://github.com/cake-tech/cake_wallet) [[apk]](https://github.com/cake-tech/cake_wallet/releases) - An open source wallet for iOS and Android supporting XMR and other currencies.
 - [Coin Wallet](https://coin.space/) [[code]](https://github.com/CoinSpace/CoinSpace) - A self-custodial multicurrency wallet for multiple platforms (iOS and Android).
-- [Midori Wallet](https://astian.org/midori-wallet/) [[code]]([https://github.com/CoinSpace/CoinSpace](https://github.com/midoriwallet/midoriwallet)) - A lightweight, private, reliable, and secure wallet for Android, iOS.
+- [Midori Wallet](https://astian.org/midori-wallet/) [[code]](https://github.com/midoriwallet/midoriwallet) - A lightweight, private, reliable, and secure wallet for Android, iOS.
 
 ### Desktop
 - 🔵 [Electron Cash CashToken](https://electroncash.org) [[release]](https://github.com/Electron-Cash/Electron-Cash/releases/tag/4.3.0) [[code]](https://github.com/Electron-Cash/Electron-Cash/) - Electron Cash with CashTokens.
 - [Flowee Pay](https://flowee.org/products/pay/) [[code]](https://codeberg.org/flowee/pay) - A payment solution, a wallet, a basis for your new product. But currently just a desktop wallet.
 - 🔵 [Cashonize (quasar)](https://github.com/cashonize/cashonize-wallet/tags) [[code]](https://github.com/cashonize/cashonize-wallet) - Cashonize rewrite with Quasar & Vue-js
 - [Coin Wallet](https://coin.space/) [[code]](https://github.com/CoinSpace/CoinSpace) - A self-custodial multicurrency wallet for multiple platforms (Windows, macOS and Linux).
-- [Midori Wallet](https:/astian.org/midori-wallet/) [[code]]([https://github.com/CoinSpace/CoinSpace](https://github.com/midoriwallet/midoriwallet)) - A lightweight, private, reliable, and secure wallet.
+- [Midori Wallet](https://astian.org/midori-wallet/) [[code]](https://github.com/midoriwallet/midoriwallet) - A lightweight, private, reliable, and secure wallet.
 
 ### Web Browser
-- [Midori Wallet](https:/astian.org/midori-wallet/) [[code]]([https://github.com/CoinSpace/CoinSpace](https://github.com/midoriwallet/midoriwallet)) - A lightweight, private, reliable, and secure wallet Coming sooon.
+- [Midori Wallet](https://astian.org/midori-wallet/) [[code]](https://github.com/midoriwallet/midoriwallet) - A lightweight, private, reliable, and secure wallet Coming sooon.
 
 #### Electron-Cash Plugins
 


### PR DESCRIPTION
The three Midori Wallet entries in README.md have a malformed nested-link in the [[code]] section that copy-pasted from CoinSpace and never had its inner brackets cleaned up:

  [[code]]([https://github.com/CoinSpace/CoinSpace](https://github.com/midoriwallet/midoriwallet))

Markdown can't parse a link whose URL is itself a link. This PR replaces it with the clearly-intended target:

  [[code]](https://github.com/midoriwallet/midoriwallet)

Also fixes `https:/astian.org` (single slash) -> `https://astian.org` on the Desktop and Web Browser entries.

Verified target URLs are alive (HTTP 200): https://github.com/midoriwallet/midoriwallet and https://astian.org/midori-wallet/.

Affects three lines (Mobile / Desktop / Web Browser sections).